### PR TITLE
fix: `getConfiguration` cause crash if Monaco < 0.19.0

### DIFF
--- a/src/emacs/index.ts
+++ b/src/emacs/index.ts
@@ -215,11 +215,12 @@ export class EmacsExtension implements monaco.IDisposable {
 export function getConfiguration(editor: monaco.editor.IStandaloneCodeEditor): Configuration {
   // Support for Monaco < 0.19.0
   if (typeof editor['getConfiguration'] === 'function') {
-    const config = editor['getConfiguration']().viewInfo;
+    const { viewInfo, contribInfo } = editor['getConfiguration']();
+
     return {
-      seedSearchStringFromSelection: config.contribInfo.find.seedSearchStringFromSelection,
-      cursorStyle: TextEditorCursorStyle[config.cursorStyle].toLowerCase() as CursorStyle,
-      cursorBlinking: TextEditorCursorBlinkingStyle[config.cursorBlinking].toLowerCase() as CursorBlinking,
+      seedSearchStringFromSelection: contribInfo.find.seedSearchStringFromSelection,
+      cursorStyle: TextEditorCursorStyle[viewInfo.cursorStyle].toLowerCase() as CursorStyle,
+      cursorBlinking: TextEditorCursorBlinkingStyle[viewInfo.cursorBlinking].toLowerCase() as CursorBlinking,
     };
   }
 


### PR DESCRIPTION
Seems like a copy-paste accident. 😅

https://github.com/brijeshb42/monaco-emacs/commit/29d217a2e8af11676d30713d119a642eab8524fe#diff-aaff2492978db8084ffef059c5495ca7L410